### PR TITLE
FIX #40: Changed behavior of project name string parsing

### DIFF
--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -25,14 +25,14 @@ export const getProjects = (nameWithNamespace) => {
   if (nameWithNamespace == null || nameWithNamespace === '') {
     return Promise.reject(new Error('nameWithNamespace is empty'))
   }
-  return fitch.preparedGet(`/projects/${nameWithNamespace.replace('/', '%2F')}`)
+  return fitch.preparedGet(`/projects/${nameWithNamespace.replace(/\//g, '%2F')}`)
 }
 
 export const getBranch = (projectId, branchName) => {
   if (projectId == null || branchName == null) {
     return Promise.reject(new Error('projectId or branchName are empty'))
   }
-  const b = '' + branchName.replace('/', '%2F')
+  const b = '' + branchName.replace(/\//g, '%2F')
   return fitch.preparedGet(`/projects/${projectId}/repository/branches/${b}`)
 }
 
@@ -68,7 +68,7 @@ export const getCommits = (projectId, branchName) => {
   if (projectId == null || branchName == null || branchName === '') {
     return Promise.reject(new Error('projectId or branchName are empty'))
   }
-  return fitch.preparedGet(`/projects/${projectId}/repository/commits/${('' + branchName).replace('/', '%2F')}`)
+  return fitch.preparedGet(`/projects/${projectId}/repository/commits/${('' + branchName).replace(/\//g, '%2F')}`)
 }
 
 export default {

--- a/src/projects.js
+++ b/src/projects.js
@@ -15,12 +15,11 @@ export const getProjectsByQuerystring = (projectsParam) => {
   const repositories = projectsParam.split(',')
   for (const x in repositories) {
     try {
-      const repos = repositories[x].split('/')
-      const namespace = repos[0].trim()
-      const project = repos[1].trim()
+      const namespace = repositories[x].substring(0, repositories[x].lastIndexOf('/'))
+      let project = repositories[x].substring(repositories[x].lastIndexOf('/') + 1)
       let branch = 'master'
-      if (repos.length > 2) {
-        branch = repos[2].trim()
+      if (project.includes(':')) {
+        [project, branch] = project.split(':')
       }
       newProjects.push({
         description: '',

--- a/src/projects.js
+++ b/src/projects.js
@@ -15,6 +15,9 @@ export const getProjectsByQuerystring = (projectsParam) => {
   const repositories = projectsParam.split(',')
   for (const x in repositories) {
     try {
+      if (!repositories[x].includes('/')) {
+        throw Error(`Project pattern isn't correct`)
+      }
       const namespace = repositories[x].substring(0, repositories[x].lastIndexOf('/'))
       let project = repositories[x].substring(repositories[x].lastIndexOf('/') + 1)
       let branch = 'master'

--- a/test/unit/specs/projects.spec.js
+++ b/test/unit/specs/projects.spec.js
@@ -45,7 +45,7 @@ describe('Projects File', () => {
   })
   describe('Compatibility Mode', () => {
     it('Should load project pattern from url param', () => {
-      const projectsParam = 'namespace1/project1/branch1'
+      const projectsParam = 'namespace1/project1:branch1'
       const projects = getProjectsByQuerystring(projectsParam)
       expect('namespace1').toEqual(projects[0].namespace)
       expect('project1').toEqual(projects[0].project)
@@ -60,6 +60,13 @@ describe('Projects File', () => {
     it('Should return empty projects', () => {
       const projects = getProjectsByQuerystring('a,b,c')
       expect(projects.length).toEqual(0)
+    })
+    it('Should load project with subgroup namespace pattern from url param', () => {
+      const projectsParam = 'namespace1/subgroup1/project1:branch1'
+      const projects = getProjectsByQuerystring(projectsParam)
+      expect('namespace1/subgroup1').toEqual(projects[0].namespace)
+      expect('project1').toEqual(projects[0].project)
+      expect('branch1').toEqual(projects[0].branch)
     })
   })
 })


### PR DESCRIPTION
Fixed replace pattern to replace every occurrence of "/" in the project namespace string.
Fixed logic in project parsing from url to properly parse namespace in subgroup.
Changed branch parsing by colon

now this pattern will work properly:

`http://gitlab-ci-monitor/?gitlab=gitlab.com&token=my_token&projects=group/subgroup/project:develop`
