### PR TITLE
Fix: Get last tag by name

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "json-beautify": "1.0.1",
     "moment": "2.20.1",
     "opn": "5.2.0",
+    "semver-compare": "1.0.0",
     "vue": "2.5.13"
   },
   "devDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -423,7 +423,7 @@ var root = new Vue({
         const lastPipelineId = data['last_pipeline'].id
         getTags(project.id)
           .then((response) => {
-            const tag = getTopItem(response.data)
+            const tag = getTopItemByName(response.data)
             getPipeline(project.id, lastPipelineId)
               .then((pipeline) => {
                 const lastPipeline = pipeline.data

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const cmp = require('semver-compare')
+
 import {CREATED, MANUAL, SKIPPED} from './status'
 
 export const getParameterByName = (name, url) => {
@@ -33,4 +35,11 @@ export const getTopItem = (list) => {
     }
     lastValidEntry = entry
   }) || lastValidEntry
+}
+
+export const getTopItemByName = (list) => {
+  if (!Array.isArray(list) || list.length === 0) {
+    return
+  }
+  return list.sort(cmp).reverse()[0];
 }

--- a/test/unit/specs/utils.spec.js
+++ b/test/unit/specs/utils.spec.js
@@ -1,6 +1,7 @@
 import {
   getParameterByName,
-  getTopItem
+  getTopItem,
+  getTopItemByName
 } from '@/utils'
 
 describe('Utilities', () => {
@@ -9,7 +10,7 @@ describe('Utilities', () => {
     const topItem = getTopItem(arr)
     expect('a').toEqual(topItem)
   })
-  it('Shout return undefined when passa empty array', () => {
+  it('Should return undefined when empty array', () => {
     const arr = []
     const topItem = getTopItem(arr)
     expect(topItem).toEqual(undefined)
@@ -50,5 +51,10 @@ describe('Utilities', () => {
       const hideVersion = getParameterByName('hideVersion', url)
       expect(hideVersion).toBeTruthy()
     })
+  })
+  it('Should return latest tag by name', () => {
+    const arr = ['0.9.0', '0.11.0', '1.0.1']
+    const topItem = getTopItemByName(arr)
+    expect(topItem).toEqual('1.0.1')
   })
 })


### PR DESCRIPTION
Hi, This is my first contribution to this repo so may need some help in getting this merged.

Not sure if you require the creation of a new issue but the selection of tags is currently returning the first element from GitLab API (curl -X GET http://GitLabHost/api/v4/projects/id/repository/tags) when it should be a little bit more smarter than that.

The approach I took was to select the latest tag by name which I think is a reasonable option.

Please review and let me know any questions.