### PR TITLE
Improve tag sort operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "json-beautify": "1.0.1",
     "moment": "2.20.1",
     "opn": "5.2.0",
-    "semver-compare": "1.0.0",
+    "semver-sort": "0.0.4",
     "vue": "2.5.13"
   },
   "devDependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-const cmp = require('semver-compare')
+const sort = require('semver-sort')
 
 import {CREATED, MANUAL, SKIPPED} from './status'
 
@@ -41,5 +41,5 @@ export const getTopItemByName = (list) => {
   if (!Array.isArray(list) || list.length === 0) {
     return
   }
-  return list.sort(cmp).reverse()[0];
+  return sort.desc(list)[0];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-const sort = require('semver-sort')
+import sort from 'semver-sort'
 
 import {CREATED, MANUAL, SKIPPED} from './status'
 
@@ -41,5 +41,5 @@ export const getTopItemByName = (list) => {
   if (!Array.isArray(list) || list.length === 0) {
     return
   }
-  return sort.desc(list)[0];
+  return sort.desc(list).shift()
 }

--- a/test/unit/specs/utils.spec.js
+++ b/test/unit/specs/utils.spec.js
@@ -62,9 +62,9 @@ describe('Utilities', () => {
     const topItem = getTopItemByName(arr)
     expect(topItem).toEqual('v1.0.1')
   })
-  it('Should return latest tag by name with v prefix', () => {
-    const arr = ['v0.9.0-alpha', 'v0.11.0-beta', 'v0.11.0']
+  it('Should return latest tag by name with v prefix and suffixes', () => {
+    const arr = ['v0.9.0-alpha', 'v0.11.0-beta', 'v0.11.0-alpha']
     const topItem = getTopItemByName(arr)
-    expect(topItem).toEqual('v0.11.0')
+    expect(topItem).toEqual('v0.11.0-beta')
   })
 })

--- a/test/unit/specs/utils.spec.js
+++ b/test/unit/specs/utils.spec.js
@@ -57,4 +57,14 @@ describe('Utilities', () => {
     const topItem = getTopItemByName(arr)
     expect(topItem).toEqual('1.0.1')
   })
+  it('Should return latest tag by name with v prefix', () => {
+    const arr = ['v0.9.0', 'v0.11.0', 'v1.0.1']
+    const topItem = getTopItemByName(arr)
+    expect(topItem).toEqual('v1.0.1')
+  })
+  it('Should return latest tag by name with v prefix', () => {
+    const arr = ['v0.9.0-alpha', 'v0.11.0-beta', 'v0.11.0']
+    const topItem = getTopItemByName(arr)
+    expect(topItem).toEqual('v0.11.0')
+  })
 })


### PR DESCRIPTION
Given the feedback from https://github.com/emilianoeloi/gitlab-ci-dashboard/pull/62, an improved version.

Cc: @emilianoeloi , @marek-ganko 